### PR TITLE
rewrote projared.py functions with pathlib

### DIFF
--- a/projared.py
+++ b/projared.py
@@ -1,97 +1,72 @@
 import os;
 import json;
 import logging;
+from pathlib import Path
 import sys;
 
 from JumJumJr import jumjumjr;
 
-def current_directory():
-    return os.path.dirname(__file__);
 
-def log_validation():
+def create_paths():
 
     ## Log Directory & File
-    log_dir = os.path.join(current_directory(), 'logs');
-    log_path = os.path.join(log_dir, 'log.txt');
-
-    ## Whole process to ensure that logging is possible
-    if not os.path.exists(log_path):
-        if not os.path.exists(log_dir):
-            os.mkdir(log_dir);
-        with open(log_path, 'x') as f:
-            f.write("Beginning of log file.\n");
-        logging.basicConfig(filename=log_path,format='%(asctime)s - %(message)s', level=logging.DEBUG);
-        logging.info("Created by " + os.path.basename(__file__));
-    else:
-        logging.basicConfig(filename=log_path,format='%(asctime)s - %(message)s', level=logging.DEBUG);
-
-    return;
-
-def status_validation(twitch_data):
+    log_dir = Path.cwd() / "logs";
+    log_path = Path.cwd() / "logs" / "log.txt";
+    os.makedirs(log_dir, exist_ok=True);
 
     ## Status Directory & File
-    status_dir = os.path.join(current_directory(), 'status');
-    status_path = os.path.join(status_dir, 'status.json');
+    status_dir = Path.cwd() / "status";
+    status_path = Path.cwd() / "status" / "status.json";
+    os.makedirs(status_dir, exist_ok=True);
 
-    ## Whole process to ensure that status file is available
-    if not os.path.exists(status_path):
-        if not os.path.exists(status_dir):
-            os.mkdir(status_dir);
-            logging.info("Created status directory.");
-        with open(status_path, 'x') as f:
-            # Dumps latest Twitch API data into file
-            # No point in continuing if that file was missing
-            f.write(json.dumps(twitch_data));
+    return log_path, status_path;
+
+
+def read_previous_status(status_path):
+    try:
+        text_data = status_path.read_text();
+        json_data = json.loads(text_data);
+
+        return json_data
+    except FileNotFoundError:
+        ## If no file present, create one with default values.
+        json_data = {"status": "Offline"};
+        text_data = json.dumps(json_data);
+        status_path.write_text(text_data);
         logging.info("Status file created. Stopping script prematurely.");
         sys.exit(0);
-    else:
-        with open(status_path, 'r') as f:
-            try:
-                prev = json.load(f);
-            except:
-                logging.info("Status file was unable to be read.");
-        return prev;
 
-def status_update(twitch_data):
 
-    ## Status Directory & File
-    status_dir = os.path.join(current_directory(), 'status');
-    status_path = os.path.join(status_dir, 'status.json');
-    
-    with open(status_path, 'w') as q:
-        json.dump(twitch_data, q);
+def update_status(status_path, twitch_data):
+    text_data = json.dumps(twitch_data);
+    status_path.write_text(text_data);
     return;
 
-def main():
 
-    ## Ensures log directory and file is present
-    log_validation();
-
-    logging.info("Starting script in " + os.path.basename(__file__));
-
-    ## Grabs latest Twitch API data
-    twitch_data = jumjumjr.data();
-
-    ## Ensures status directory and file is present
-    prev_data = status_validation(twitch_data);
-
+def compare_status(current_data, prev_data):
     ## Just access keys directly and not loop through them
-    if twitch_data['status'] == 'Offline' and prev_data['status'] == 'Offline':
+    if current_data["status"] == "Offline" and prev_data["status"] == "Offline":
         print("Do nothing!");
-    elif twitch_data['status'] == 'Offline' and prev_data['status'] == 'Online':
+    elif current_data["status"] == "Offline" and prev_data["status"] == "Online":
         print("We're going live!");
-    elif twitch_data['status'] == 'Online' and prev_data['status'] == 'Offline':
+    elif current_data["status"] == "Online" and prev_data["status"] == "Offline":
         print("He's done for the day");
     else:
         print("Probably hosting.");
-
-    ## Updating status file with new data
-    status_update(twitch_data);
-
-    logging.info("Exiting " + os.path.basename(__file__));
-
     return;
 
-if __name__ == '__main__':
-    main();
+
+if __name__ == "__main__":
+    log_path, status_path = create_paths();
+    logging.FileHandler(filename=log_path, mode="a", encoding=None, delay=False);
+    logging.basicConfig(filename=log_path, format="%(asctime)s - %(message)s", level=logging.INFO);
+    logging.info("Starting script in " + os.path.basename(__file__));
+
+    current_twitch_data = jumjumjr.data();
+    prev_twitch_data = read_previous_status(status_path);
+
+    update_status(status_path, current_twitch_data);
+    compare_status(current_twitch_data, prev_twitch_data);
+    logging.info("Exiting " + os.path.basename(__file__));
+
     logging.info("End of script.\n");


### PR DESCRIPTION
Bulk of the existing code related to opening, closing and writing files can be replaced with the `pathlib` functionality. `write_text()` takes care of opening and closing files so we don't have to use the `with open()` statement.

`os.makedirs` with `exist_ok=True` won't create a directory or raise errors if it already exists.

Additionally, I renamed most of the functions to make the code self-documented and easier to read. As a consequence, the `read_previous_status()` function doesn't fetch fresh twitch data anymore. I think it's best if functions do one thing only. If we need, we can add fetching twitch data on the first run elsewhere.